### PR TITLE
Allow multiple event objects in one socket data event

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import net from 'net';
+import os from 'os';
 import querystring from 'querystring';
 import url from 'url';
 
@@ -64,8 +65,20 @@ class Device {
       );
 
       this.socket.on('data', (data) => {
-        const response = JSON.parse(data.toString('utf8'));
-        if (response.id === this.id && response.result[0] === 'ok') {
+        const responses = data
+          .toString("utf8")
+          .trim()
+          .split(os.EOL)
+          .map((ev) => JSON.parse(ev.trim()));
+
+        const isSuccessful = responses.some(
+          (response) =>
+            response.id === this.id &&
+            response.result &&
+            response.result[0] === "ok"
+        );
+
+        if (isSuccessful) {
           this.socket.destroy();
           resolve();
         } else {


### PR DESCRIPTION
In some cases the device socket responded with a data string that
contained multiple objects seperated by an empty line.
If this construct was passed to JSON.stringify it failed with an
unhandled error as the json structure was not valid.
Splitting the response by empty lines and handling each event fixes
this.

In my case I received the following data string after calling `powerOn`
method on the device:
```
{"id":0, "result":["ok"]}
{"method":"props","params":{"power":"off"}}
```